### PR TITLE
Feature get user info

### DIFF
--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -223,7 +223,12 @@ const usersController = {
     const tweets = selfTweets.concat(selfReplies).sort((a, b) => b.createdAt - a.createdAt);
     const uniqueTweets = [...new Map(tweets.map((item) => [item.id, item])).values()];
 
-    return res.render('index', { user: getUser(req), selfTweetsReplies: uniqueTweets });
+    return res.render('index', {
+      notMain          : true,
+      user             : getUser(req),
+      selfTweetsReplies: uniqueTweets,
+      title            : `${getUser(req).name}\n${tweets.length} 推文`,
+    });
   },
   // 使用者喜歡的內容清單
   getSelfLikes: (req, res) => {
@@ -247,7 +252,12 @@ const usersController = {
         (tweet) => (tweet.LikeCount > 0 && tweet.isLiked === true),
       );
 
-      return res.render('index', { user: getUser(req), likedTweets });
+      return res.render('index', {
+        notMain: true,
+        user   : getUser(req),
+        likedTweets,
+        title  : `${getUser(req).name}\n${tweets.length} 推文`,
+      });
     });
   },
   // 使用者編輯個人資料

--- a/routes/modules/tweets.js
+++ b/routes/modules/tweets.js
@@ -5,12 +5,12 @@ const router = express.Router();
 const tweetsController = require('../../controllers/tweetsController');
 const likesController = require('../../controllers/likesController');
 
-/* GET reply page. */
-router.get('/:tweetId', tweetsController.getReplyPage);
-
 /* GET home page. */
 router.get('/', tweetsController.getIndexPage);
 router.post('/', tweetsController.createTweet);
+
+/* GET reply page. */
+router.get('/:tweetId', tweetsController.getReplyPage);
 
 router.post('/:tweetId/like', likesController.addLike);
 router.delete('/:tweetId/unlike', likesController.removeLike);

--- a/routes/modules/users.js
+++ b/routes/modules/users.js
@@ -23,7 +23,7 @@ router.put('/users/:id/edit', authenticated, usersController.putAccount);
 // 使用者個人推文清單
 router.get('/users/:id/tweets', authenticated, usersController.getSelfTweets);
 // 使用者個人推文及回覆清單
-router.get('/user/self/tweetsReplies/', authenticated, usersController.getSelfTweetsReplies);
+router.get('/users/:id/tweetsReplies/', authenticated, usersController.getSelfTweetsReplies);
 // 使用者喜歡的內容清單
 router.get('/users/:id/likes', authenticated, usersController.getSelfLikes);
 

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -20,7 +20,7 @@
         <p><a href="/signin">前台登入</a></p>
       {{else}}
         <p class="mr-1"><a href="/signup">註冊Alphitter</a></p>
-        <p class="mr-1">·</p>
+        <p class="mr-1">&#183;</p>
         <p><a href="/admin/signin">後台登入</a></p>
       {{/if}}
       

--- a/views/partials/column_main.hbs
+++ b/views/partials/column_main.hbs
@@ -1,7 +1,7 @@
 <div id="mainblock-header" class="position-sticky d-flex align-items-center w-100 bg-white header-block p-3" style="white-space: pre-wrap;">
   {{!-- TODO: 如果不是主頁就需要顯示那個頁面的標題 --}}
   {{#if notMain}}
-  <a class="nav-link" href="javascript:history.back()"><i class="fas fa-arrow-left pr-2"></i></a>
+  <a class="nav-link" href="/tweets"><i class="fas fa-arrow-left pr-2"></i></a>
   {{title}}
   {{else}}
   首頁

--- a/views/partials/column_main_user.hbs
+++ b/views/partials/column_main_user.hbs
@@ -29,7 +29,7 @@
     <a class="nav-link" href="/users/{{user.id}}/tweets/">推文</a>
   </li>
   <li class="nav-item text-center {{#if (isdefined selfTweetsReplies)}}active{{/if}}">
-    <a class="nav-link" href="/user/self/tweetsReplies">推文與回覆</a>
+    <a class="nav-link" href="/users/{{user.id}}/tweetsReplies">推文與回覆</a>
   </li>
   <li class="nav-item text-center {{#if (isdefined likedTweets)}}active{{/if}}">
     <a class="nav-link" href="/users/{{user.id}}/likes">喜歡的內容</a>

--- a/views/partials/column_side.hbs
+++ b/views/partials/column_side.hbs
@@ -7,10 +7,15 @@
     <li class="list-group-item">
       <div class="d-flex justify-content-between">
         <div class="d-flex align-item-start">
-         <img class="img-fluid rounded-circle mr-3 my-auto" src="{{this.avatar}}" alt="" style="max-height: 70px;">
+          <a href="/users/{{this.id}}/tweets">
+            <img class="img-fluid rounded-circle mr-3" src="{{this.avatar}}" alt=""style="max-height: 70px;">
+          </a>
+ 
         <div class="name pr-2 align-items-center my-auto">
-          <strong>{{this.name}}</strong>
-          <div class="info"><span class="username">@{{this.account}}</span></div>
+          <a href="/users/{{this.id}}/tweets"><strong>{{this.name}}</strong></a>
+          <div class="info"><span class="username"><a href="/users/{{this.id}}/tweets">@{{this.account}}</span></a>
+          </div>
+          </a>
         </div>
         </div>
         <div class="my-auto">

--- a/views/partials/listitem_reply.hbs
+++ b/views/partials/listitem_reply.hbs
@@ -2,10 +2,18 @@
 <div class="list-item d-flex align-items-start p-3" style="min-height: 120px;">
   <div class="align-items-start p-3">
     <div class="d-flex align-item-start">
+      <a href="/users/{{tweet.User.id}}/tweets">
       <img class="img-fluid rounded-circle mr-3" src="{{tweet.User.avatar}}" alt="" style="max-height: 70px;">
+      </a>
       <div class="name pr-2 align-items-center my-auto">
-        <strong>{{tweet.User.name}}</strong>
-        <div class="info"><span class="username">@{{tweet.User.account}}</span></div>
+        <a href="/users/{{tweet.User.id}}/tweets">
+          <strong>{{tweet.User.name}}</strong>
+        </a>
+        <div class="info">
+          <a href="/users/{{tweet.User.id}}/tweets">
+          <span class="username">@{{tweet.User.account}}</span>
+          </a>
+        </div>
       </div>
     </div> 
     <div class="item-desc pt-2 pb-3 w-70" style="word-wrap:break-word; font-size:1.3em; font-weight:bold;">
@@ -34,19 +42,24 @@
     <div class="reply-list">
       {{#each tweet.Replies}}
         <div class="list-item d-flex align-items-start pr-3 py-3" style="min-height: 120px;">
-          <img class="img-fluid rounded-circle mr-3" src="{{this.User.avatar}}" alt="" style="max-height: 70px;">
+          <a href="/users/{{this.User.id}}/tweets">
+          <img class="img-fluid rounded-circle mr-3" src="{{this.User.avatar}}" alt="" style="max-height: 70px;"></a>
           <div>
             <div class="item-header d-flex d-row d-flex align-items-center">
               <div class="name pr-2">
+                <a href="/users/{{this.User.id}}/tweets">
                 <strong>{{this.User.name}}</strong>
+                </a>
               </div>
               <div class="info">
+                <a href="/users/{{this.User.id}}/tweets">
                 <span class="username">@{{this.User.account}}</span>
+                </a>
                 &#183;
                 <span class="posttime">{{moment this.createdAt}}</span>
               </div>
             </div>
-            <div class="pt-2">回覆@{{../tweet.User.account}}</div>
+            <div class="pt-2">回覆<a href="/users/{{../tweet.User.id}}/tweets">@{{../tweet.User.account}}</a></div>
             <div class="item-desc pt-2 pb-3">
               {{this.comment}}
             </div>

--- a/views/partials/listitem_tweet.hbs
+++ b/views/partials/listitem_tweet.hbs
@@ -1,32 +1,38 @@
-<a href="/reply_list/{{this.id}}" style="text-decoration:none;color:black;">
 <div class="list-item d-flex align-items-start p-3 pointer tweet-gray" style="min-height: 120px;">
-  <img class="img-fluid rounded-circle mr-3" src="{{this.User.avatar}}" alt="">
+  <a href="/users/{{this.User.id}}/tweets">
+    <img class="img-fluid rounded-circle mr-3" src="{{this.User.avatar}}" alt="" style="max-height: 70px;">
+  </a>
   <div>
     <div class="item-header d-flex d-row d-flex align-items-center">
       <div class="name pr-2">
-        <strong>{{this.User.name}}</strong>
+        <a href="/users/{{this.User.id}}/tweets"><strong>{{this.User.name}}</strong></a>
       </div>
       <div class="info">
-        <span class="username">{{this.User.account}}</span>
+        <a href="/users/{{this.User.id}}/tweets">
+          <span class="username">@{{this.User.account}}</span>
+        </a>
         &#183;
         <span class="posttime">{{moment this.createdAt}}</span>
       </div>
     </div>
-    <div class="item-desc pt-2 pb-3">
-      {{this.description}}
-    </div>
+    <a href="/reply_list/{{this.id}}" style="text-decoration:none;color:black;">
+      <div class="item-desc pt-2 pb-3">
+        {{this.description}}
+      </div>
+    </a>
     <div class="item-other d-flex flex-row">
       <span class="pr-3 mr-3"><i class="far fa-comment pr-2"></i>{{this.ReplyCount}}</span>
       {{#if this.isLiked }}
-        <form action="/tweets/{{this.id}}/unlike?_method=DELETE" method="POST" class="ml-3 pl-3">
-          <button class="btn btn-link text-orange p-0" type="submit"><i class="far fa-heart pr-2 text-orange"></i>{{this.LikeCount}}</button>
-        </form>
+      <form action="/tweets/{{this.id}}/unlike?_method=DELETE" method="POST" class="ml-3 pl-3">
+        <button class="btn btn-link text-orange p-0" type="submit"><i
+            class="far fa-heart pr-2 text-orange"></i>{{this.LikeCount}}</button>
+      </form>
       {{else}}
-        <form action="/tweets/{{this.id}}/like/" method="POST" class="ml-3 pl-3">
-          <button class="btn btn-link text-lightgrey p-0" type="submit"><i class="far fa-heart pr-2"></i>{{this.LikeCount}}</button>
-        </form>
+      <form action="/tweets/{{this.id}}/like/" method="POST" class="ml-3 pl-3">
+        <button class="btn btn-link text-lightgrey p-0" type="submit"><i
+            class="far fa-heart pr-2"></i>{{this.LikeCount}}</button>
+      </form>
       {{/if}}
     </div>
   </div>
 </div>
-</a>


### PR DESCRIPTION
[Trello 卡片 點擊貼文中使用者頭像時，能瀏覽該使用者的個人資料及推文](https://trello.com/c/wf0ABc6G/9-%E9%BB%9E%E6%93%8A%E8%B2%BC%E6%96%87%E4%B8%AD%E4%BD%BF%E7%94%A8%E8%80%85%E9%A0%AD%E5%83%8F%E6%99%82%EF%BC%8C%E8%83%BD%E7%80%8F%E8%A6%BD%E8%A9%B2%E4%BD%BF%E7%94%A8%E8%80%85%E7%9A%84%E5%80%8B%E4%BA%BA%E8%B3%87%E6%96%99%E5%8F%8A%E6%8E%A8%E6%96%87)
[Trello 卡片 個人資料 三個 tabs 的標題修正](https://trello.com/c/ZLqCw4sy/52-%E5%80%8B%E4%BA%BA%E8%B3%87%E6%96%99%E9%A0%81%E9%9D%A2-title-%E6%98%AF%E7%94%A8%E6%88%B6%E5%90%8D-%E7%B8%BD%E5%85%B1%E5%B9%BE%E5%89%87%E6%8E%A8%E6%96%87)

- 改變 tweetsReplies 路由
- 頭像、名字和帳號都可連到該用戶的個人頁面。

待調整 UI：
- (急）瀏覽個人頁面，若不是自己的帳號，其頁面為三個按鈕（信箱、鈴噹、跟隨）
- 名字和帳號的連結 UI 再調整沒有藍色底線