### PR TITLE
fix: add user-role value when create new user

### DIFF
--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -44,6 +44,7 @@ const usersController = {
         account : req.body.account,
         avatar  : `https://loremflickr.com/300/300/portrait/?lock=${Math.random() * 100}`,
         cover   : `https://loremflickr.com/300/300/portrait/?lock=${Math.random() * 100}`,
+        role    : 'user',
       }).then(() => {
         req.flash('success_messages', '成功註冊帳號');
         res.redirect('/signin');


### PR DESCRIPTION
在User.create新增 role  : 'user'，使新註冊的用戶資料role不會是null，並且可以出現在畫面右側的topfollowing column
