### PR TITLE
fix: user info following button

### DIFF
--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -264,6 +264,7 @@ const usersController = {
 
     const tweets = selfTweets.concat(selfReplies).sort((a, b) => b.createdAt - a.createdAt);
     const uniqueTweets = [...new Map(tweets.map((item) => [item.id, item])).values()];
+    user.isFollowed = helpers.getUser(req).Followings.map((d) => d.id).includes(user.id);
 
     return res.render('index', {
       user,
@@ -304,6 +305,8 @@ const usersController = {
       LikeCount : tweet.Likes.length,
       isLiked   : user.LikedTweets.map((d) => d.id).includes(tweet.id),
     }));
+
+    user.isFollowed = helpers.getUser(req).Followings.map((d) => d.id).includes(user.id);
 
     return res.render('index', {
       user,


### PR DESCRIPTION
修補: 當使用者進入其他用戶的個人資料頁時，上面的"跟隨"按鈕在切換至分頁"推文與回覆"或"喜歡的內容"時，能正常顯示為"跟隨"或"正在跟隨"的狀態